### PR TITLE
Cooke testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ pip install pyside2  # OPTIONAL: Only if you want to use otioview
 ```
 
 You can now use LMF `.yml` files natively in OpenTimelineIO. For example,
-`otiocat -i my-LMF-test-file.yml -o my-LMF-marker-set.otio` will generate an
+`otioconvert -i my-LMF-test-file.yml -o my-LMF-marker-set.otio` will generate an
 otio file with a `SerializableObject` as the top-level object containing
 markers with the LMF record metadata.
 
@@ -31,6 +31,18 @@ of this might look like:
 
 `otioview -a create_clip=True my-LMF-test-file.yml`
 
+The kinematic data (magnetometer, gyro, accelerometer) from Cooke lenses can be
+very large, and if it is not needed for downstream processing it can be omitted
+by setting the adapter flag `omit_kinematic` to `True`.
+
+For faster YAML processing, libyaml can be installed. On MacOS, the easiest way to 
+install this is to use Homebrew and install libyaml, and then reinstall the pyyaml
+package:
+
+```
+brew install libyaml
+pip --no-cache-dir install --force-reinstall --global-option='build_ext' --global-option='-I/usr/local/include' --global-option='-L/usr/local/lib' pyyaml
+```
 
 ## Developing
 
@@ -44,8 +56,7 @@ and put it in `tests/sample_data/lens-data-2020052713471590587226.yml`.
 I like to use curl:
 
 ```
-$ curl https://bitbucket.org/cookeoptics/cookelensmetadata/raw/426174755ae456b8788
-518e8b64b59b5db80ceb1/SampleFiles/lens-data-2020052713471590587226.yml > tests/sample_data/lens-data-2020052713471590587226.yml
+$ curl https://bitbucket.org/cookeoptics/cookelensmetadata/raw/426174755ae456b8788518e8b64b59b5db80ceb1/SampleFiles/lens-data-2020052713471590587226.yml > tests/sample_data/lens-data-2020052713471590587226.yml
 ```
 
 Then install the test requirements in your environment:

--- a/otio_cookelensmetadata/adapter.py
+++ b/otio_cookelensmetadata/adapter.py
@@ -57,6 +57,7 @@ class RecordType:
     root: str = "rt"
     raw_category: str = "unknown"
     identifier: List[str] = field(default_factory=list)
+    _KINEMATIC_RECORD_TYPES = {"magnetometer", "accelerometer", "gyro"}
 
     def __str__(self):
         return ".".join([self.root, self.raw_category] + self.identifier)
@@ -70,8 +71,7 @@ class RecordType:
 
     @property
     def is_kinematic(self) -> bool:
-         kinematic_strings = ["magnetometer", "accelerometer", "gyro"]
-         return any(substring in str(self) for substring in kinematic_strings)
+         return any(substring in str(self) for substring in self._KINEMATIC_RECORD_TYPES)
 
     @category.setter
     def category(self, new_category: Category):

--- a/otio_cookelensmetadata/adapter.py
+++ b/otio_cookelensmetadata/adapter.py
@@ -145,10 +145,9 @@ def _read_from_documents(
             continue
 
         # If the omit_kinematic flag is set to True, skip any record type
-        # containing a kinematic type.
-        if omit_kinematic:
-            if record_type.is_kinematic:
-                continue
+        # containing kinematic data.
+        if omit_kinematic and record_type.is_kinematic:
+            continue
 
         # Handle pulling top-level metata for certain contexts
         if record_type.identifier == ["recorder", "info"]:

--- a/otio_cookelensmetadata/adapter.py
+++ b/otio_cookelensmetadata/adapter.py
@@ -100,6 +100,14 @@ def _decode_timecode(
     return tc_string
 
 
+def _normalize_rate( in_rate: float 
+) -> float:
+    """
+    Normalizes a frame rate float to one of the standard rates
+    """
+    return round(in_rate * 1001)/1001
+
+
 def _read_from_documents(
     documents: Iterable[Mapping],
     create_clip=False,
@@ -133,6 +141,7 @@ def _read_from_documents(
         # Handle pulling top-level metata for certain contexts
         if record_type.identifier == ["recorder", "info"]:
             tc_rate = document.get(FRAME_RATE_KEY)
+            tc_rate = _normalize_rate( tc_rate )
             tc_is_dropframe = document.get(DROP_FRAME_KEY, False)
 
         category = record_type.category


### PR DESCRIPTION
In testing with a relatively large set of Cooke files, I added a new adapter flag to omit kinematic data from the output to make the size more manageable when kinematic information isn't needed, and also cleaned up bruised frame rate numbers coming in from yaml files.